### PR TITLE
fix: update packageJson reading technique to avoid warning message

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -11,10 +11,14 @@ import { loadConfig, setApiKey, getApiKey, saveConfig } from "./config.js";
 import { readFileSync } from "fs";
 import { input, select, password } from "@inquirer/prompts";
 import { maskApiKey } from "./utils.js";
-import packageJson from "../package.json" with { type: "json" } 
+import path from "path";
+import { PackageJson } from "./types.js";
 
 config();
 
+const packageJson: PackageJson = JSON.parse(
+  readFileSync(path.resolve(process.cwd(), "package.json"), "utf-8")
+);
 const program = new Command();
 
 // Get program metadata from package.json

--- a/src/types.ts
+++ b/src/types.ts
@@ -47,3 +47,22 @@ export interface SimpleGitFile {
   changes: number;
   binary?: boolean;
 }
+
+export interface PackageJson {
+  name: string;
+  version: string;
+  description: string;
+  main: string;
+  scripts: {
+    [key: string]: string;
+  };
+  keywords: string[];
+  author: string;
+  license: string;
+  dependencies: {
+    [key: string]: string;
+  };
+  devDependencies: {
+    [key: string]: string;
+  };
+}


### PR DESCRIPTION
## Update packageJson reading technique and add PackageJson interface

### Changes

We made two significant changes to the codebase:

1. **Updated packageJson reading technique**: In `src/index.ts`, we fixed an issue where a warning message was being displayed due to an incorrect way of importing `package.json`. We replaced this with a correct import statement, ensuring that the file is read properly.
2. **Added PackageJson interface**: We created a new file `src/types.ts` and added a `PackageJson` interface to define the structure of a `package.json` file. This interface will be used for type safety and consistency throughout the application.

### Why these changes were necessary

These changes were necessary to resolve an issue with package imports and to improve code maintainability by introducing a clear definition of the `package.json` format.

### Breaking Changes or Important Notes

* The updated import statement in `src/index.ts` may require adjustments to any existing code that relies on the previous import method.
* The new `PackageJson` interface is a crucial addition for type safety and consistency. Please ensure that all uses of `package.json` in your code adhere to this new format.

### Review and Feedback

Review these changes carefully, especially if you've customized package imports or rely on specific properties in the `package.json` file. If you have any questions or concerns, please don't hesitate to reach out!
